### PR TITLE
refactor: Add "common" library for shared code

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -4,10 +4,12 @@ FROM node:20.18.1-alpine AS build
 WORKDIR /app
 
 COPY ./package*.json ./
+COPY ./common/package*.json ./common/
 COPY ./client/package*.json ./client/
 RUN npm ci
 
 COPY ./tsconfig.json ./
+COPY ./common ./common
 COPY ./client ./client
 RUN npm run build
 
@@ -17,9 +19,11 @@ WORKDIR /app
 RUN apk add --no-cache tini
 
 COPY ./package*.json ./
+COPY ./common/package*.json ./common/
 COPY ./client/package*.json ./client/
 RUN npm ci --omit=dev
 
+COPY --from=build /app/common/dist ./common/dist
 COPY --from=build /app/client/dist ./client/dist
 
 USER node

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -1,12 +1,9 @@
+import type { UpdateResponse } from '@meyfa/ddns-common'
+
 export interface UpdateOptions {
   url: URL
   secret: string
   signal?: AbortSignal
-}
-
-export interface UpdateResponse {
-  ip: string
-  modified: boolean
 }
 
 export async function update(options: UpdateOptions): Promise<UpdateResponse> {

--- a/common/package.json
+++ b/common/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "name": "@meyfa/ddns-common",
+  "type": "module",
+  "main": "dist/main.js",
+  "types": "dist/main.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "lint": "tsc --noEmit"
+  }
+}

--- a/common/src/main.ts
+++ b/common/src/main.ts
@@ -1,0 +1,4 @@
+export interface UpdateResponse {
+  ip: string
+  modified: boolean
+}

--- a/common/tsconfig.json
+++ b/common/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "sourceMap": true,
+    "declaration": true,
+    "noEmit": false
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "@meyfa/ddns",
       "workspaces": [
+        "common",
         "client",
         "worker"
       ],
@@ -26,6 +27,9 @@
         "node": ">=20",
         "npm": ">=9"
       }
+    },
+    "common": {
+      "name": "@meyfa/ddns-common"
     },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.3.4",
@@ -601,6 +605,10 @@
     },
     "node_modules/@meyfa/ddns-cloudflare-worker": {
       "resolved": "worker",
+      "link": true
+    },
+    "node_modules/@meyfa/ddns-common": {
+      "resolved": "common",
       "link": true
     },
     "node_modules/@types/node": {

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "private": true,
   "name": "@meyfa/ddns",
   "scripts": {
-    "lint": "npm run lint --workspaces",
-    "build": "npm run build --workspace=client",
-    "deploy": "npm run deploy --workspace=worker"
+    "lint": "npm run build --workspace=common && npm run lint --workspaces",
+    "build": "npm run build --workspace=common && npm run build --workspace=client",
+    "deploy": "npm run build --workspace=common && npm run deploy --workspace=worker"
   },
   "workspaces": [
+    "common",
     "client",
     "worker"
   ],

--- a/worker/src/main.ts
+++ b/worker/src/main.ts
@@ -1,13 +1,10 @@
+import type { UpdateResponse } from '@meyfa/ddns-common'
+
 interface Env {
   DDNS_SECRET?: string
   CLOUDFLARE_API_TOKEN?: string
   CLOUDFLARE_ZONE_ID?: string
   CLOUDFLARE_RECORD_NAME?: string
-}
-
-interface UpdateResponse {
-  ip: string
-  modified: boolean
 }
 
 const API = new URL('https://api.cloudflare.com/client/v4/')


### PR DESCRIPTION
The `UpdateResponse` interface was previously duplicated between worker and client. In future patches, additional pieces of similar code can be placed into common, such as environment variable parsing.