### PR TITLE
fix: Move environment validation to common

### DIFF
--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -1,50 +1,23 @@
-export interface Env {
+import { validatePositiveInteger, validateString, validateUrl } from '@meyfa/ddns-common'
+
+export interface Config {
   DDNS_URL: URL
   DDNS_SECRET: string
   DDNS_UPDATE_INTERVAL: number
   DDNS_REQUEST_TIMEOUT: number
 }
 
-export function validateEnvironment(env: NodeJS.ProcessEnv): Env {
-  const result = {
+export function validateEnvironment(env: NodeJS.ProcessEnv): Config {
+  const config = {
     DDNS_URL: validateUrl(env, 'DDNS_URL'),
     DDNS_SECRET: validateString(env, 'DDNS_SECRET'),
     DDNS_UPDATE_INTERVAL: validatePositiveInteger(env, 'DDNS_UPDATE_INTERVAL'),
     DDNS_REQUEST_TIMEOUT: validatePositiveInteger(env, 'DDNS_REQUEST_TIMEOUT')
   }
 
-  if (result.DDNS_UPDATE_INTERVAL < result.DDNS_REQUEST_TIMEOUT) {
+  if (config.DDNS_UPDATE_INTERVAL < config.DDNS_REQUEST_TIMEOUT) {
     throw new Error('DDNS_UPDATE_INTERVAL must be greater than or equal to DDNS_REQUEST_TIMEOUT')
   }
 
-  return result
-}
-
-function validateUrl(env: NodeJS.ProcessEnv, key: string): URL {
-  const input = env[key]
-  if (input == null || input === '' || !URL.canParse(input)) {
-    throw new Error(`${key} must be a valid URL`)
-  }
-  return new URL(input)
-}
-
-function validateString(env: NodeJS.ProcessEnv, key: string): string {
-  const input = env[key]
-  if (input == null || input === '') {
-    throw new Error(`${key} is required`)
-  }
-  return input
-}
-
-function validatePositiveInteger(env: NodeJS.ProcessEnv, key: string): number {
-  const input = env[key]
-  const error = `${key} must be a positive integer`
-  if (input == null || input === '' || !/^\d+$/.test(input)) {
-    throw new Error(error)
-  }
-  const value = Number.parseInt(input, 10)
-  if (value <= 0) {
-    throw new Error(error)
-  }
-  return value
+  return config
 }

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -3,7 +3,7 @@ import { validateEnvironment } from './config.js'
 import { log } from './log.js'
 import { setTimeout as delay } from 'node:timers/promises'
 
-const env = validateEnvironment(process.env)
+const config = validateEnvironment(process.env)
 
 const abortController = new AbortController()
 for (const signal of ['SIGTERM', 'SIGINT'] as const) {
@@ -16,11 +16,11 @@ for (const signal of ['SIGTERM', 'SIGINT'] as const) {
 function run() {
   log('info', 'Updating DDNS')
 
-  const signal = AbortSignal.any([abortController.signal, AbortSignal.timeout(env.DDNS_REQUEST_TIMEOUT * 1000)])
+  const signal = AbortSignal.any([abortController.signal, AbortSignal.timeout(config.DDNS_REQUEST_TIMEOUT * 1000)])
 
   update({
-    url: env.DDNS_URL,
-    secret: env.DDNS_SECRET,
+    url: config.DDNS_URL,
+    secret: config.DDNS_SECRET,
     signal
   })
     .then((result) => {
@@ -35,7 +35,7 @@ while (!abortController.signal.aborted) {
   run()
 
   try {
-    await delay(env.DDNS_UPDATE_INTERVAL * 1000, undefined, { signal: abortController.signal })
+    await delay(config.DDNS_UPDATE_INTERVAL * 1000, undefined, { signal: abortController.signal })
   } catch (ignored: unknown) {
     // aborted
   }

--- a/common/src/main.ts
+++ b/common/src/main.ts
@@ -2,3 +2,34 @@ export interface UpdateResponse {
   ip: string
   modified: boolean
 }
+
+type EnvDict = Record<string, string | undefined>
+
+export function validateUrl(env: EnvDict, key: string): URL {
+  const input = env[key]
+  if (input == null || input === '' || !URL.canParse(input)) {
+    throw new Error(`${key} must be a valid URL`)
+  }
+  return new URL(input)
+}
+
+export function validateString(env: EnvDict, key: string): string {
+  const input = env[key]
+  if (input == null || input === '') {
+    throw new Error(`${key} must be a non-empty string`)
+  }
+  return input
+}
+
+export function validatePositiveInteger(env: EnvDict, key: string): number {
+  const input = env[key]
+  const error = `${key} must be a positive integer`
+  if (input == null || input === '' || !/^\d+$/.test(input)) {
+    throw new Error(error)
+  }
+  const value = Number.parseInt(input, 10)
+  if (value <= 0) {
+    throw new Error(error)
+  }
+  return value
+}


### PR DESCRIPTION
Uses common functions to validate environment variables in the client and the worker, reducing code duplication. The validation result is renamed to "config" instead of "env", since "env" is just the source of the data, but did not properly describe its usage.